### PR TITLE
fix: correct CODEOWNERS to reference @GLB-BDS-SF/sf-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @GLB-BDS-SF/bds-sf-team will be requested for
+# @GLB-BDS-SF/sf-team will be requested for
 # review when someone opens a pull request, per
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-*   @GLB-BDS-SF/bds-sf-team
+*   @GLB-BDS-SF/sf-team


### PR DESCRIPTION
Ensures `.github/CODEOWNERS` requests review from `@GLB-BDS-SF/sf-team` on every pull request.

- Pattern `*` assigns the SF team as default code owner.